### PR TITLE
support for Marshaling Project object

### DIFF
--- a/gopom.go
+++ b/gopom.go
@@ -92,7 +92,7 @@ func (p *Properties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err e
 }
 
 // MarshalXML marshals Properties into XML.
-func (p *Properties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (p Properties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 	tokens := []xml.Token{start}
 
@@ -109,7 +109,6 @@ func (p *Properties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 			return err
 		}
 	}
-
 	// flush to ensure tokens are written
 	return e.Flush()
 }

--- a/gopom.go
+++ b/gopom.go
@@ -91,6 +91,29 @@ func (p *Properties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err e
 	return nil
 }
 
+// MarshalXML marshals Properties into XML.
+func (p *Properties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+
+	tokens := []xml.Token{start}
+
+	for key, value := range p.Entries {
+		t := xml.StartElement{Name: xml.Name{Local: key}}
+		tokens = append(tokens, t, xml.CharData(value), xml.EndElement{Name: t.Name})
+	}
+
+	tokens = append(tokens, xml.EndElement{Name: start.Name})
+
+	for _, t := range tokens {
+		err := e.EncodeToken(t)
+		if err != nil {
+			return err
+		}
+	}
+
+	// flush to ensure tokens are written
+	return e.Flush()
+}
+
 type Parent struct {
 	GroupID      string `xml:"groupId"`
 	ArtifactID   string `xml:"artifactId"`

--- a/gopom_test.go
+++ b/gopom_test.go
@@ -729,3 +729,26 @@ func Test_ParsingNotifierConfigurations(t *testing.T) {
 	assert.Equal(t, "value2", p.Properties.Entries["key2"])
 	assert.Equal(t, "value3", p.Properties.Entries["key3"])
 }
+
+func Test_MarshalingProjectToXML(t *testing.T) {
+	ignitePlugin := Plugin{
+		GroupID:    "org.apache.ignite",
+		ArtifactID: "ignite-core",
+		Version:    "2.14.0",
+	}
+
+	// Add plugin to build plugins of original project p and marshal it to XML.
+	p.Build.Plugins = append(p.Build.Plugins, ignitePlugin)
+
+	// Marshal the pom back to xml
+	marshaledXml, err := xml.MarshalIndent(p, "  ", "    ")
+	assert.Nil(t, err)
+
+	// Parse the marshaled XML back to a Project object
+	parsedPom := Project{}
+	err = xml.Unmarshal(marshaledXml, &parsedPom)
+	assert.Nil(t, err)
+
+	// Check that the two object are equal.
+	assert.Equal(t, p, parsedPom)
+}


### PR DESCRIPTION
At present, when you want to marshal the parsed object back to XML, it gives `error: xml unsupported type: map[string]string`

- Similar to UnmarshalXML for properties object, added MarshalXML for properties
- Now we can marshal the parsed object back to xml file