### PR TITLE
Omit empty fields when marshalling to xml

### DIFF
--- a/gopom.go
+++ b/gopom.go
@@ -36,36 +36,36 @@ func ParseFromReader(reader io.Reader) (*Project, error) {
 }
 
 type Project struct {
-	XMLName                xml.Name               `xml:"project"`
-	ModelVersion           string                 `xml:"modelVersion"`
-	Parent                 Parent                 `xml:"parent"`
-	GroupID                string                 `xml:"groupId"`
-	ArtifactID             string                 `xml:"artifactId"`
-	Version                string                 `xml:"version"`
-	Packaging              string                 `xml:"packaging"`
-	Name                   string                 `xml:"name"`
-	Description            string                 `xml:"description"`
-	URL                    string                 `xml:"url"`
-	InceptionYear          string                 `xml:"inceptionYear"`
-	Organization           Organization           `xml:"organization"`
-	Licenses               []License              `xml:"licenses>license"`
-	Developers             []Developer            `xml:"developers>developer"`
-	Contributors           []Contributor          `xml:"contributors>contributor"`
-	MailingLists           []MailingList          `xml:"mailingLists>mailingList"`
-	Prerequisites          Prerequisites          `xml:"prerequisites"`
-	Modules                []string               `xml:"modules>module"`
-	SCM                    Scm                    `xml:"scm"`
-	IssueManagement        IssueManagement        `xml:"issueManagement"`
-	CIManagement           CIManagement           `xml:"ciManagement"`
-	DistributionManagement DistributionManagement `xml:"distributionManagement"`
-	DependencyManagement   DependencyManagement   `xml:"dependencyManagement"`
-	Dependencies           []Dependency           `xml:"dependencies>dependency"`
-	Repositories           []Repository           `xml:"repositories>repository"`
-	PluginRepositories     []PluginRepository     `xml:"pluginRepositories>pluginRepository"`
-	Build                  Build                  `xml:"build"`
-	Reporting              Reporting              `xml:"reporting"`
-	Profiles               []Profile              `xml:"profiles>profile"`
-	Properties             Properties             `xml:"properties"`
+	XMLName                *xml.Name               `xml:"project,omitempty"`
+	ModelVersion           *string                 `xml:"modelVersion,omitempty"`
+	Parent                 *Parent                 `xml:"parent,omitempty"`
+	GroupID                *string                 `xml:"groupId,omitempty"`
+	ArtifactID             *string                 `xml:"artifactId,omitempty"`
+	Version                *string                 `xml:"version,omitempty"`
+	Packaging              *string                 `xml:"packaging,omitempty"`
+	Name                   *string                 `xml:"name,omitempty"`
+	Description            *string                 `xml:"description,omitempty"`
+	URL                    *string                 `xml:"url,omitempty"`
+	InceptionYear          *string                 `xml:"inceptionYear,omitempty"`
+	Organization           *Organization           `xml:"organization,omitempty"`
+	Licenses               *[]License              `xml:"licenses>license,omitempty"`
+	Developers             *[]Developer            `xml:"developers>developer,omitempty"`
+	Contributors           *[]Contributor          `xml:"contributors>contributor,omitempty"`
+	MailingLists           *[]MailingList          `xml:"mailingLists>mailingList,omitempty"`
+	Prerequisites          *Prerequisites          `xml:"prerequisites,omitempty"`
+	Modules                *[]string               `xml:"modules>module,omitempty"`
+	SCM                    *Scm                    `xml:"scm,omitempty"`
+	IssueManagement        *IssueManagement        `xml:"issueManagement,omitempty"`
+	CIManagement           *CIManagement           `xml:"ciManagement,omitempty"`
+	DistributionManagement *DistributionManagement `xml:"distributionManagement,omitempty"`
+	DependencyManagement   *DependencyManagement   `xml:"dependencyManagement,omitempty"`
+	Dependencies           *[]Dependency           `xml:"dependencies>dependency,omitempty"`
+	Repositories           *[]Repository           `xml:"repositories>repository,omitempty"`
+	PluginRepositories     *[]PluginRepository     `xml:"pluginRepositories>pluginRepository,omitempty"`
+	Build                  *Build                  `xml:"build,omitempty"`
+	Reporting              *Reporting              `xml:"reporting,omitempty"`
+	Profiles               *[]Profile              `xml:"profiles>profile,omitempty"`
+	Properties             *Properties             `xml:"properties,omitempty"`
 }
 
 type Properties struct {
@@ -114,271 +114,271 @@ func (p Properties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 }
 
 type Parent struct {
-	GroupID      string `xml:"groupId"`
-	ArtifactID   string `xml:"artifactId"`
-	Version      string `xml:"version"`
-	RelativePath string `xml:"relativePath"`
+	GroupID      *string `xml:"groupId,omitempty"`
+	ArtifactID   *string `xml:"artifactId,omitempty"`
+	Version      *string `xml:"version,omitempty"`
+	RelativePath *string `xml:"relativePath,omitempty"`
 }
 
 type Organization struct {
-	Name string `xml:"name"`
-	URL  string `xml:"url"`
+	Name *string `xml:"name,omitempty"`
+	URL  *string `xml:"url,omitempty"`
 }
 
 type License struct {
-	Name         string `xml:"name"`
-	URL          string `xml:"url"`
-	Distribution string `xml:"distribution"`
-	Comments     string `xml:"comments"`
+	Name         *string `xml:"name,omitempty"`
+	URL          *string `xml:"url,omitempty"`
+	Distribution *string `xml:"distribution,omitempty"`
+	Comments     *string `xml:"comments,omitempty"`
 }
 
 type Developer struct {
-	ID              string     `xml:"id"`
-	Name            string     `xml:"name"`
-	Email           string     `xml:"email"`
-	URL             string     `xml:"url"`
-	Organization    string     `xml:"organization"`
-	OrganizationURL string     `xml:"organizationUrl"`
-	Roles           []string   `xml:"roles>role"`
-	Timezone        string     `xml:"timezone"`
-	Properties      Properties `xml:"properties"`
+	ID              *string     `xml:"id,omitempty"`
+	Name            *string     `xml:"name,omitempty"`
+	Email           *string     `xml:"email,omitempty"`
+	URL             *string     `xml:"url,omitempty"`
+	Organization    *string     `xml:"organization,omitempty"`
+	OrganizationURL *string     `xml:"organizationUrl,omitempty"`
+	Roles           *[]string   `xml:"roles>role,omitempty"`
+	Timezone        *string     `xml:"timezone,omitempty"`
+	Properties      *Properties `xml:"properties,omitempty"`
 }
 
 type Contributor struct {
-	Name            string     `xml:"name"`
-	Email           string     `xml:"email"`
-	URL             string     `xml:"url"`
-	Organization    string     `xml:"organization"`
-	OrganizationURL string     `xml:"organizationUrl"`
-	Roles           []string   `xml:"roles>role"`
-	Timezone        string     `xml:"timezone"`
-	Properties      Properties `xml:"properties"`
+	Name            *string     `xml:"name,omitempty"`
+	Email           *string     `xml:"email,omitempty"`
+	URL             *string     `xml:"url,omitempty"`
+	Organization    *string     `xml:"organization,omitempty"`
+	OrganizationURL *string     `xml:"organizationUrl,omitempty"`
+	Roles           *[]string   `xml:"roles>role,omitempty"`
+	Timezone        *string     `xml:"timezone,omitempty"`
+	Properties      *Properties `xml:"properties,omitempty"`
 }
 
 type MailingList struct {
-	Name          string   `xml:"name"`
-	Subscribe     string   `xml:"subscribe"`
-	Unsubscribe   string   `xml:"unsubscribe"`
-	Post          string   `xml:"post"`
-	Archive       string   `xml:"archive"`
-	OtherArchives []string `xml:"otherArchives>otherArchive"`
+	Name          *string   `xml:"name,omitempty"`
+	Subscribe     *string   `xml:"subscribe,omitempty"`
+	Unsubscribe   *string   `xml:"unsubscribe,omitempty"`
+	Post          *string   `xml:"post,omitempty"`
+	Archive       *string   `xml:"archive,omitempty"`
+	OtherArchives *[]string `xml:"otherArchives>otherArchive,omitempty"`
 }
 
 type Prerequisites struct {
-	Maven string `xml:"maven"`
+	Maven *string `xml:"maven,omitempty"`
 }
 
 type Scm struct {
-	Connection          string `xml:"connection"`
-	DeveloperConnection string `xml:"developerConnection"`
-	Tag                 string `xml:"tag"`
-	URL                 string `xml:"url"`
+	Connection          *string `xml:"connection,omitempty"`
+	DeveloperConnection *string `xml:"developerConnection,omitempty"`
+	Tag                 *string `xml:"tag,omitempty"`
+	URL                 *string `xml:"url,omitempty"`
 }
 
 type IssueManagement struct {
-	System string `xml:"system"`
-	URL    string `xml:"url"`
+	System *string `xml:"system,omitempty"`
+	URL    *string `xml:"url,omitempty"`
 }
 
 type CIManagement struct {
-	System    string     `xml:"system"`
-	URL       string     `xml:"url"`
-	Notifiers []Notifier `xml:"notifiers>notifier"`
+	System    *string     `xml:"system,omitempty"`
+	URL       *string     `xml:"url,omitempty"`
+	Notifiers *[]Notifier `xml:"notifiers>notifier,omitempty"`
 }
 
 type Notifier struct {
-	Type          string     `xml:"type"`
-	SendOnError   bool       `xml:"sendOnError"`
-	SendOnFailure bool       `xml:"sendOnFailure"`
-	SendOnSuccess bool       `xml:"sendOnSuccess"`
-	SendOnWarning bool       `xml:"sendOnWarning"`
-	Address       string     `xml:"address"`
-	Configuration Properties `xml:"configuration"`
+	Type          *string     `xml:"type,omitempty"`
+	SendOnError   *bool       `xml:"sendOnError,omitempty"`
+	SendOnFailure *bool       `xml:"sendOnFailure,omitempty"`
+	SendOnSuccess *bool       `xml:"sendOnSuccess,omitempty"`
+	SendOnWarning *bool       `xml:"sendOnWarning,omitempty"`
+	Address       *string     `xml:"address,omitempty"`
+	Configuration *Properties `xml:"configuration,omitempty"`
 }
 
 type DistributionManagement struct {
-	Repository         Repository `xml:"repository"`
-	SnapshotRepository Repository `xml:"snapshotRepository"`
-	Site               Site       `xml:"site"`
-	DownloadURL        string     `xml:"downloadUrl"`
-	Relocation         Relocation `xml:"relocation"`
-	Status             string     `xml:"status"`
+	Repository         *Repository `xml:"repository,omitempty"`
+	SnapshotRepository *Repository `xml:"snapshotRepository,omitempty"`
+	Site               *Site       `xml:"site,omitempty"`
+	DownloadURL        *string     `xml:"downloadUrl,omitempty"`
+	Relocation         *Relocation `xml:"relocation,omitempty"`
+	Status             *string     `xml:"status,omitempty"`
 }
 
 type Site struct {
-	ID   string `xml:"id"`
-	Name string `xml:"name"`
-	URL  string `xml:"url"`
+	ID   *string `xml:"id,omitempty"`
+	Name *string `xml:"name,omitempty"`
+	URL  *string `xml:"url,omitempty"`
 }
 
 type Relocation struct {
-	GroupID    string `xml:"groupId"`
-	ArtifactID string `xml:"artifactId"`
-	Version    string `xml:"version"`
-	Message    string `xml:"message"`
+	GroupID    *string `xml:"groupId,omitempty"`
+	ArtifactID *string `xml:"artifactId,omitempty"`
+	Version    *string `xml:"version,omitempty"`
+	Message    *string `xml:"message,omitempty"`
 }
 
 type DependencyManagement struct {
-	Dependencies []Dependency `xml:"dependencies>dependency"`
+	Dependencies *[]Dependency `xml:"dependencies>dependency,omitempty"`
 }
 
 type Dependency struct {
-	GroupID    string      `xml:"groupId"`
-	ArtifactID string      `xml:"artifactId"`
-	Version    string      `xml:"version"`
-	Type       string      `xml:"type"`
-	Classifier string      `xml:"classifier"`
-	Scope      string      `xml:"scope"`
-	SystemPath string      `xml:"systemPath"`
-	Exclusions []Exclusion `xml:"exclusions>exclusion"`
-	Optional   string      `xml:"optional"`
+	GroupID    *string      `xml:"groupId,omitempty"`
+	ArtifactID *string      `xml:"artifactId,omitempty"`
+	Version    *string      `xml:"version,omitempty"`
+	Type       *string      `xml:"type,omitempty"`
+	Classifier *string      `xml:"classifier,omitempty"`
+	Scope      *string      `xml:"scope,omitempty"`
+	SystemPath *string      `xml:"systemPath,omitempty"`
+	Exclusions *[]Exclusion `xml:"exclusions>exclusion,omitempty"`
+	Optional   *string      `xml:"optional,omitempty"`
 }
 
 type Exclusion struct {
-	ArtifactID string `xml:"artifactId"`
-	GroupID    string `xml:"groupId"`
+	ArtifactID *string `xml:"artifactId,omitempty"`
+	GroupID    *string `xml:"groupId,omitempty"`
 }
 
 type Repository struct {
-	UniqueVersion bool             `xml:"uniqueVersion"`
-	Releases      RepositoryPolicy `xml:"releases"`
-	Snapshots     RepositoryPolicy `xml:"snapshots"`
-	ID            string           `xml:"id"`
-	Name          string           `xml:"name"`
-	URL           string           `xml:"url"`
-	Layout        string           `xml:"layout"`
+	UniqueVersion *bool             `xml:"uniqueVersion,omitempty"`
+	Releases      *RepositoryPolicy `xml:"releases,omitempty"`
+	Snapshots     *RepositoryPolicy `xml:"snapshots,omitempty"`
+	ID            *string           `xml:"id,omitempty"`
+	Name          *string           `xml:"name,omitempty"`
+	URL           *string           `xml:"url,omitempty"`
+	Layout        *string           `xml:"layout,omitempty"`
 }
 
 type RepositoryPolicy struct {
-	Enabled        string `xml:"enabled"`
-	UpdatePolicy   string `xml:"updatePolicy"`
-	ChecksumPolicy string `xml:"checksumPolicy"`
+	Enabled        *string `xml:"enabled,omitempty"`
+	UpdatePolicy   *string `xml:"updatePolicy,omitempty"`
+	ChecksumPolicy *string `xml:"checksumPolicy,omitempty"`
 }
 
 type PluginRepository struct {
-	Releases  RepositoryPolicy `xml:"releases"`
-	Snapshots RepositoryPolicy `xml:"snapshots"`
-	ID        string           `xml:"id"`
-	Name      string           `xml:"name"`
-	URL       string           `xml:"url"`
-	Layout    string           `xml:"layout"`
+	Releases  *RepositoryPolicy `xml:"releases,omitempty"`
+	Snapshots *RepositoryPolicy `xml:"snapshots,omitempty"`
+	ID        *string           `xml:"id,omitempty"`
+	Name      *string           `xml:"name,omitempty"`
+	URL       *string           `xml:"url,omitempty"`
+	Layout    *string           `xml:"layout,omitempty"`
 }
 
 type BuildBase struct {
-	DefaultGoal      string           `xml:"defaultGoal"`
-	Resources        []Resource       `xml:"resources>resource"`
-	TestResources    []Resource       `xml:"testResources>testResource"`
-	Directory        string           `xml:"directory"`
-	FinalName        string           `xml:"finalName"`
-	Filters          []string         `xml:"filters>filter"`
-	PluginManagement PluginManagement `xml:"pluginManagement"`
-	Plugins          []Plugin         `xml:"plugins>plugin"`
+	DefaultGoal      *string           `xml:"defaultGoal,omitempty"`
+	Resources        *[]Resource       `xml:"resources>resource,omitempty"`
+	TestResources    *[]Resource       `xml:"testResources>testResource,omitempty"`
+	Directory        *string           `xml:"directory,omitempty"`
+	FinalName        *string           `xml:"finalName,omitempty"`
+	Filters          *[]string         `xml:"filters>filter,omitempty"`
+	PluginManagement *PluginManagement `xml:"pluginManagement,omitempty"`
+	Plugins          *[]Plugin         `xml:"plugins>plugin,omitempty"`
 }
 
 type Build struct {
-	SourceDirectory       string      `xml:"sourceDirectory"`
-	ScriptSourceDirectory string      `xml:"scriptSourceDirectory"`
-	TestSourceDirectory   string      `xml:"testSourceDirectory"`
-	OutputDirectory       string      `xml:"outputDirectory"`
-	TestOutputDirectory   string      `xml:"testOutputDirectory"`
-	Extensions            []Extension `xml:"extensions>extension"`
+	SourceDirectory       *string      `xml:"sourceDirectory,omitempty"`
+	ScriptSourceDirectory *string      `xml:"scriptSourceDirectory,omitempty"`
+	TestSourceDirectory   *string      `xml:"testSourceDirectory,omitempty"`
+	OutputDirectory       *string      `xml:"outputDirectory,omitempty"`
+	TestOutputDirectory   *string      `xml:"testOutputDirectory,omitempty"`
+	Extensions            *[]Extension `xml:"extensions>extension,omitempty"`
 	BuildBase
 }
 
 type Extension struct {
-	GroupID    string `xml:"groupId"`
-	ArtifactID string `xml:"artifactId"`
-	Version    string `xml:"version"`
+	GroupID    *string `xml:"groupId,omitempty"`
+	ArtifactID *string `xml:"artifactId,omitempty"`
+	Version    *string `xml:"version,omitempty"`
 }
 
 type Resource struct {
-	TargetPath string   `xml:"targetPath"`
-	Filtering  string   `xml:"filtering"`
-	Directory  string   `xml:"directory"`
-	Includes   []string `xml:"includes>include"`
-	Excludes   []string `xml:"excludes>exclude"`
+	TargetPath *string   `xml:"targetPath,omitempty"`
+	Filtering  *string   `xml:"filtering,omitempty"`
+	Directory  *string   `xml:"directory,omitempty"`
+	Includes   *[]string `xml:"includes>include,omitempty"`
+	Excludes   *[]string `xml:"excludes>exclude,omitempty"`
 }
 
 type PluginManagement struct {
-	Plugins []Plugin `xml:"plugins>plugin"`
+	Plugins *[]Plugin `xml:"plugins>plugin,omitempty"`
 }
 
 type Plugin struct {
-	GroupID       string            `xml:"groupId"`
-	ArtifactID    string            `xml:"artifactId"`
-	Version       string            `xml:"version"`
-	Extensions    string            `xml:"extensions"`
-	Executions    []PluginExecution `xml:"executions>execution"`
-	Dependencies  []Dependency      `xml:"dependencies>dependency"`
-	Inherited     string            `xml:"inherited"`
-	Configuration Properties        `xml:"configuration"`
+	GroupID       *string            `xml:"groupId,omitempty"`
+	ArtifactID    *string            `xml:"artifactId,omitempty"`
+	Version       *string            `xml:"version,omitempty"`
+	Extensions    *string            `xml:"extensions,omitempty"`
+	Executions    *[]PluginExecution `xml:"executions>execution,omitempty"`
+	Dependencies  *[]Dependency      `xml:"dependencies>dependency,omitempty"`
+	Inherited     *string            `xml:"inherited,omitempty"`
+	Configuration *Properties        `xml:"configuration,omitempty"`
 }
 
 type PluginExecution struct {
-	ID            string     `xml:"id"`
-	Phase         string     `xml:"phase"`
-	Goals         []string   `xml:"goals>goal"`
-	Inherited     string     `xml:"inherited"`
-	Configuration Properties `xml:"configuration"`
+	ID            *string     `xml:"id,omitempty"`
+	Phase         *string     `xml:"phase,omitempty"`
+	Goals         *[]string   `xml:"goals>goal,omitempty"`
+	Inherited     *string     `xml:"inherited,omitempty"`
+	Configuration *Properties `xml:"configuration,omitempty"`
 }
 
 type Reporting struct {
-	ExcludeDefaults string            `xml:"excludeDefaults"`
-	OutputDirectory string            `xml:"outputDirectory"`
-	Plugins         []ReportingPlugin `xml:"plugins>plugin"`
+	ExcludeDefaults *string            `xml:"excludeDefaults,omitempty"`
+	OutputDirectory *string            `xml:"outputDirectory,omitempty"`
+	Plugins         *[]ReportingPlugin `xml:"plugins>plugin,omitempty"`
 }
 
 type ReportingPlugin struct {
-	GroupID       string      `xml:"groupId"`
-	ArtifactID    string      `xml:"artifactId"`
-	Version       string      `xml:"version"`
-	Inherited     string      `xml:"inherited"`
-	ReportSets    []ReportSet `xml:"reportSets>reportSet"`
-	Configuration Properties  `xml:"configuration"`
+	GroupID       *string      `xml:"groupId,omitempty"`
+	ArtifactID    *string      `xml:"artifactId,omitempty"`
+	Version       *string      `xml:"version,omitempty"`
+	Inherited     *string      `xml:"inherited,omitempty"`
+	ReportSets    *[]ReportSet `xml:"reportSets>reportSet,omitempty"`
+	Configuration *Properties  `xml:"configuration,omitempty"`
 }
 
 type ReportSet struct {
-	ID            string     `xml:"id"`
-	Reports       []string   `xml:"reports>report"`
-	Inherited     string     `xml:"inherited"`
-	Configuration Properties `xml:"configuration"`
+	ID            *string     `xml:"id,omitempty"`
+	Reports       *[]string   `xml:"reports>report,omitempty"`
+	Inherited     *string     `xml:"inherited,omitempty"`
+	Configuration *Properties `xml:"configuration,omitempty"`
 }
 
 type Profile struct {
-	ID                     string                 `xml:"id"`
-	Activation             Activation             `xml:"activation"`
-	Build                  BuildBase              `xml:"build"`
-	Modules                []string               `xml:"modules>module"`
-	DistributionManagement DistributionManagement `xml:"distributionManagement"`
-	Properties             Properties             `xml:"properties"`
-	DependencyManagement   DependencyManagement   `xml:"dependencyManagement"`
-	Dependencies           []Dependency           `xml:"dependencies>dependency"`
-	Repositories           []Repository           `xml:"repositories>repository"`
-	PluginRepositories     []PluginRepository     `xml:"pluginRepositories>pluginRepository"`
-	Reporting              Reporting              `xml:"reporting"`
+	ID                     *string                 `xml:"id,omitempty"`
+	Activation             *Activation             `xml:"activation,omitempty"`
+	Build                  *BuildBase              `xml:"build,omitempty"`
+	Modules                *[]string               `xml:"modules>module,omitempty"`
+	DistributionManagement *DistributionManagement `xml:"distributionManagement,omitempty"`
+	Properties             *Properties             `xml:"properties,omitempty"`
+	DependencyManagement   *DependencyManagement   `xml:"dependencyManagement,omitempty"`
+	Dependencies           *[]Dependency           `xml:"dependencies>dependency,omitempty"`
+	Repositories           *[]Repository           `xml:"repositories>repository,omitempty"`
+	PluginRepositories     *[]PluginRepository     `xml:"pluginRepositories>pluginRepository,omitempty"`
+	Reporting              *Reporting              `xml:"reporting,omitempty"`
 }
 
 type Activation struct {
-	ActiveByDefault bool               `xml:"activeByDefault"`
-	JDK             string             `xml:"jdk"`
-	OS              ActivationOS       `xml:"os"`
-	Property        ActivationProperty `xml:"property"`
-	File            ActivationFile     `xml:"file"`
+	ActiveByDefault *bool               `xml:"activeByDefault,omitempty"`
+	JDK             *string             `xml:"jdk,omitempty"`
+	OS              *ActivationOS       `xml:"os,omitempty"`
+	Property        *ActivationProperty `xml:"property,omitempty"`
+	File            *ActivationFile     `xml:"file,omitempty"`
 }
 
 type ActivationOS struct {
-	Name    string `xml:"name"`
-	Family  string `xml:"family"`
-	Arch    string `xml:"arch"`
-	Version string `xml:"version"`
+	Name    *string `xml:"name,omitempty"`
+	Family  *string `xml:"family,omitempty"`
+	Arch    *string `xml:"arch,omitempty"`
+	Version *string `xml:"version,omitempty"`
 }
 
 type ActivationProperty struct {
-	Name  string `xml:"name"`
-	Value string `xml:"value"`
+	Name  *string `xml:"name,omitempty"`
+	Value *string `xml:"value,omitempty"`
 }
 
 type ActivationFile struct {
-	Missing string `xml:"missing"`
-	Exists  string `xml:"exists"`
+	Missing *string `xml:"missing,omitempty"`
+	Exists  *string `xml:"exists,omitempty"`
 }

--- a/gopom_test.go
+++ b/gopom_test.go
@@ -21,726 +21,785 @@ func init() {
 }
 
 func TestParsing_Parent(t *testing.T) {
-	if p.Parent.ArtifactID != "test-application" {
-		t.Error("Parent.ArtifactID: expected 'test-application', got: " + p.Parent.ArtifactID)
+	if *p.Parent.ArtifactID != "test-application" {
+		t.Error("Parent.ArtifactID: expected 'test-application', got: " + *p.Parent.ArtifactID)
 	}
-	if p.Parent.GroupID != "com.test" {
-		t.Error("Parent.GroupID: expected 'com.test', got: " + p.Parent.GroupID)
+	if *p.Parent.GroupID != "com.test" {
+		t.Error("Parent.GroupID: expected 'com.test', got: " + *p.Parent.GroupID)
 	}
-	if p.Parent.Version != "1.0.0" {
-		t.Error("Parent.Version: expected '1.0.0', got: " + p.Parent.Version)
+	if *p.Parent.Version != "1.0.0" {
+		t.Error("Parent.Version: expected '1.0.0', got: " + *p.Parent.Version)
 	}
-	if p.Parent.RelativePath != "../pom.xml" {
-		t.Error("Parent.RelativePath: expected '../pom.xml', got: " + p.Parent.RelativePath)
+	if *p.Parent.RelativePath != "../pom.xml" {
+		t.Error("Parent.RelativePath: expected '../pom.xml', got: " + *p.Parent.RelativePath)
 	}
 }
 
 func TestParsing_Project(t *testing.T) {
-	if p.GroupID != "com.test" {
-		t.Error("GroupID: expected 'com.test', got: " + p.GroupID)
+	if *p.GroupID != "com.test" {
+		t.Error("GroupID: expected 'com.test', got: " + *p.GroupID)
 	}
-	if p.ArtifactID != "test-application" {
-		t.Error("ArtifactID: expected 'test-application', got: " + p.ArtifactID)
+	if *p.ArtifactID != "test-application" {
+		t.Error("ArtifactID: expected 'test-application', got: " + *p.ArtifactID)
 	}
-	if p.Version != "1.0.0" {
-		t.Error("Version: expected '1.0.0', got: " + p.Version)
+	if *p.Version != "1.0.0" {
+		t.Error("Version: expected '1.0.0', got: " + *p.Version)
 	}
-	if p.Packaging != "war" {
-		t.Error("Packaging: expected 'war', got: " + p.Packaging)
+	if *p.Packaging != "war" {
+		t.Error("Packaging: expected 'war', got: " + *p.Packaging)
 	}
-	if p.Name != "gopom-test" {
-		t.Error("Name: expected 'gopom-test', got: " + p.Name)
+	if *p.Name != "gopom-test" {
+		t.Error("Name: expected 'gopom-test', got: " + *p.Name)
 	}
-	if p.Description != "pom parser in golang" {
-		t.Error("Description: expected 'pom parser in golang', got: " + p.Description)
+	if *p.Description != "pom parser in golang" {
+		t.Error("Description: expected 'pom parser in golang', got: " + *p.Description)
 	}
-	if p.URL != "testUrl" {
-		t.Error("URL: expected 'testUrl', got: " + p.URL)
+	if *p.URL != "testUrl" {
+		t.Error("URL: expected 'testUrl', got: " + *p.URL)
 	}
-	if p.InceptionYear != "2020" {
-		t.Error("InceptionYear: expected '2020', got: " + p.InceptionYear)
+	if *p.InceptionYear != "2020" {
+		t.Error("InceptionYear: expected '2020', got: " + *p.InceptionYear)
 	}
-	if p.ModelVersion != "4.0.0" {
-		t.Error("ModelVersion: expected '4.0.0', got: " + p.ModelVersion)
+	if *p.ModelVersion != "4.0.0" {
+		t.Error("ModelVersion: expected '4.0.0', got: " + *p.ModelVersion)
 	}
 
-	if len(p.Modules) != 2 {
-		t.Error("Modules: expected len==2, got: " + strconv.Itoa(len(p.Modules)))
+	modules := *p.Modules
+	if len(modules) != 2 {
+		t.Error("Modules: expected len==2, got: " + strconv.Itoa(len(*p.Modules)))
 	} else {
-		if p.Modules[0] != "module1" {
-			t.Error("Modules[0]: expected 'module1', got: " + p.Modules[0])
+		if modules[0] != "module1" {
+			t.Error("Modules[0]: expected 'module1', got: " + modules[0])
 		}
-		if p.Modules[1] != "module2" {
-			t.Error("Modules[1]: expected 'module1', got: " + p.Modules[1])
+		if modules[1] != "module2" {
+			t.Error("Modules[1]: expected 'module1', got: " + modules[1])
 		}
 	}
 }
 
 func TestParsing_Organization(t *testing.T) {
-	if p.Organization.Name != "name" {
-		t.Error("Organization.Name: expected 'name', got: " + p.Organization.Name)
+	if *p.Organization.Name != "name" {
+		t.Error("Organization.Name: expected 'name', got: " + *p.Organization.Name)
 	}
-	if p.Organization.URL != "url" {
-		t.Error("Organization.URL: expected 'url', got: " + p.Organization.URL)
+	if *p.Organization.URL != "url" {
+		t.Error("Organization.URL: expected 'url', got: " + *p.Organization.URL)
 	}
 }
 
 func TestParsing_Licenses(t *testing.T) {
-	if len(p.Licenses) != 1 {
-		t.Error("Licenses: expected len==1, got: " + strconv.Itoa(len(p.Licenses)))
+	licenses := *p.Licenses
+	if len(licenses) != 1 {
+		t.Error("Licenses: expected len==1, got: " + strconv.Itoa(len(*p.Licenses)))
 	}
-	if p.Licenses[0].Name != "name" {
-		t.Error("Licenses.Name: expected 'name', got: " + p.Licenses[0].Name)
+	if *licenses[0].Name != "name" {
+		t.Error("Licenses.Name: expected 'name', got: " + *licenses[0].Name)
 	}
-	if p.Licenses[0].URL != "url" {
-		t.Error("Licenses.URL: expected 'url', got: " + p.Licenses[0].URL)
+	if *licenses[0].URL != "url" {
+		t.Error("Licenses.URL: expected 'url', got: " + *licenses[0].URL)
 	}
-	if p.Licenses[0].Distribution != "manual" {
-		t.Error("Licenses.Distribution: expected 'manual', got: " + p.Licenses[0].Distribution)
+	if *licenses[0].Distribution != "manual" {
+		t.Error("Licenses.Distribution: expected 'manual', got: " + *licenses[0].Distribution)
 	}
-	if p.Licenses[0].Comments != "comments" {
-		t.Error("Licenses.Comments: expected 'comments', got: " + p.Licenses[0].Comments)
+	if *licenses[0].Comments != "comments" {
+		t.Error("Licenses.Comments: expected 'comments', got: " + *licenses[0].Comments)
 	}
 }
 
 func TestParsing_Developers(t *testing.T) {
-	if len(p.Developers) != 1 {
-		t.Error("Developers: expected len==1, got: " + strconv.Itoa(len(p.Developers)))
+	developers := *p.Developers
+	if len(developers) != 1 {
+		t.Error("Developers: expected len==1, got: " + strconv.Itoa(len(*p.Developers)))
 	}
 
-	d := p.Developers[0]
-	if d.ID != "id" {
-		t.Error("Developers[0].ID: expected 'id', got: " + d.ID)
+	d := developers[0]
+	if *d.ID != "id" {
+		t.Error("Developers[0].ID: expected 'id', got: " + *d.ID)
 	}
-	if d.Name != "name" {
-		t.Error("Developers[0].Name: expected 'name', got: " + d.Name)
+	if *d.Name != "name" {
+		t.Error("Developers[0].Name: expected 'name', got: " + *d.Name)
 	}
-	if d.Email != "email" {
-		t.Error("Developers[0].Email: expected 'email', got: " + d.Email)
+	if *d.Email != "email" {
+		t.Error("Developers[0].Email: expected 'email', got: " + *d.Email)
 	}
-	if d.URL != "url" {
-		t.Error("Developers[0].URL: expected 'url', got: " + d.URL)
+	if *d.URL != "url" {
+		t.Error("Developers[0].URL: expected 'url', got: " + *d.URL)
 	}
-	if d.Organization != "organization" {
-		t.Error("Developers[0].Organization: expected 'organization', got: " + d.Organization)
+	if *d.Organization != "organization" {
+		t.Error("Developers[0].Organization: expected 'organization', got: " + *d.Organization)
 	}
-	if d.OrganizationURL != "organizationUrl" {
-		t.Error("Developers[0].OrganizationUrl: expected 'organizationUrl', got: " + d.OrganizationURL)
+	if *d.OrganizationURL != "organizationUrl" {
+		t.Error("Developers[0].OrganizationUrl: expected 'orgaeizationUrl', got: " + *d.OrganizationURL)
 	}
-	if d.Timezone != "+1" {
-		t.Error("Developers[0].Timezone: expected '+1', got: " + d.Timezone)
+	if *d.Timezone != "+1" {
+		t.Error("Developers[0].Timezone: expected '+1', got: " + *d.Timezone)
 	}
-	if len(d.Roles) != 2 {
-		t.Error("Developers: expected len==2, got: " + strconv.Itoa(len(d.Roles)))
+	roles := *d.Roles
+	if len(roles) != 2 {
+		t.Error("Developers: expected len==2, got: " + strconv.Itoa(len(roles)))
 	}
-	if d.Roles[0] != "role1" {
-		t.Error("Developers[0].Roles[0]: expected 'role1', got: " + d.Roles[0])
+	if roles[0] != "role1" {
+		t.Error("Developers[0].Roles[0]: expected 'role1', got: " + roles[0])
 	}
-	if d.Roles[1] != "role2" {
-		t.Error("Developers[0].Roles[1]: expected 'role2', got: " + d.Roles[1])
+	if roles[1] != "role2" {
+		t.Error("Developers[0].Roles[1]: expected 'role2', got: " + roles[1])
 	}
 }
 
 func TestParse_Contributors(t *testing.T) {
-	if len(p.Contributors) != 1 {
-		t.Error("Contributors: expected len==1, got: " + strconv.Itoa(len(p.Contributors)))
+	contributors := *p.Contributors
+	if len(contributors) != 1 {
+		t.Error("Contributors: expected len==1, got: " + strconv.Itoa(len(*p.Contributors)))
 	}
 
-	c := p.Contributors[0]
-	if c.Name != "name" {
-		t.Error("Contributors[0].Name: expected 'name', got: " + c.Name)
+	c := contributors[0]
+	if *c.Name != "name" {
+		t.Error("Contributors[0].Name: expected 'name', got: " + *c.Name)
 	}
-	if c.Email != "email" {
-		t.Error("Contributors[0].Email: expected 'email', got: " + c.Email)
+	if *c.Email != "email" {
+		t.Error("Contributors[0].Email: expected 'email', got: " + *c.Email)
 	}
-	if c.URL != "url" {
-		t.Error("Contributors[0].URL: expected 'url', got: " + c.URL)
+	if *c.URL != "url" {
+		t.Error("Contributors[0].URL: expected 'url', got: " + *c.URL)
 	}
-	if c.Organization != "organization" {
-		t.Error("Contributors[0].Organization: expected 'organization', got: " + c.Organization)
+	if *c.Organization != "organization" {
+		t.Error("Contributors[0].Organization: expected 'organization', got: " + *c.Organization)
 	}
-	if c.OrganizationURL != "organizationUrl" {
-		t.Error("Contributors[0].OrganizationUrl: expected 'organizationUrl', got: " + c.OrganizationURL)
+	if *c.OrganizationURL != "organizationUrl" {
+		t.Error("Contributors[0].OrganizationUrl: expected 'organizationUrl', got: " + *c.OrganizationURL)
 	}
-	if c.Timezone != "+1" {
-		t.Error("Contributors[0].Timezone: expected '+1', got: " + c.Timezone)
+	if *c.Timezone != "+1" {
+		t.Error("Contributors[0].Timezone: expected '+1', got: " + *c.Timezone)
 	}
-	if len(c.Roles) != 2 {
-		t.Error("Contributors: expected len==2, got: " + strconv.Itoa(len(c.Roles)))
+
+	roles := *c.Roles
+	if len(roles) != 2 {
+		t.Error("Contributors: expected len==2, got: " + strconv.Itoa(len(roles)))
 	}
-	if c.Roles[0] != "role1" {
-		t.Error("Contributors[0].Roles[0]: expected 'role1', got: " + c.Roles[0])
+	if roles[0] != "role1" {
+		t.Error("Contributors[0].Roles[0]: expected 'role1', got: " + roles[0])
 	}
-	if c.Roles[1] != "role2" {
-		t.Error("Developers[0].Roles[1]: expected 'role2', got: " + c.Roles[1])
+	if roles[1] != "role2" {
+		t.Error("Developers[0].Roles[1]: expected 'role2', got: " + roles[1])
 	}
 }
 
 func TestParse_MailingLists(t *testing.T) {
-	if len(p.MailingLists) != 1 {
-		t.Error("MailingLists: expected len==1, got: " + strconv.Itoa(len(p.MailingLists)))
+	mailingLists := *p.MailingLists
+	if len(mailingLists) != 1 {
+		t.Error("MailingLists: expected len==1, got: " + strconv.Itoa(len(mailingLists)))
 	}
 
-	m := p.MailingLists[0]
-	if m.Name != "name" {
-		t.Error("MailingLists[0].Name: expected 'name', got: " + m.Name)
+	m := mailingLists[0]
+	if *m.Name != "name" {
+		t.Error("MailingLists[0].Name: expected 'name', got: " + *m.Name)
 	}
-	if m.Subscribe != "subscribe" {
-		t.Error("MailingLists[0].Subscribe: expected 'subscribe', got: " + m.Subscribe)
+	if *m.Subscribe != "subscribe" {
+		t.Error("MailingLists[0].Subscribe: expected 'subscribe', got: " + *m.Subscribe)
 	}
-	if m.Unsubscribe != "unsubscribe" {
-		t.Error("MailingLists[0].Unsubscribe: expected 'unsubscribe', got: " + m.Unsubscribe)
+	if *m.Unsubscribe != "unsubscribe" {
+		t.Error("MailingLists[0].Unsubscribe: expected 'unsubscribe', got: " + *m.Unsubscribe)
 	}
-	if m.Post != "post" {
-		t.Error("MailingLists[0].Post: expected 'post', got: " + m.Post)
+	if *m.Post != "post" {
+		t.Error("MailingLists[0].Post: expected 'post', got: " + *m.Post)
 	}
-	if m.Archive != "archive" {
-		t.Error("MailingLists[0].Archive: expected 'archive', got: " + m.Archive)
+	if *m.Archive != "archive" {
+		t.Error("MailingLists[0].Archive: expected 'archive', got: " + *m.Archive)
 	}
 
-	if len(m.OtherArchives) != 2 {
-		t.Error("MailingLists.OtherArchives: expected len==2, got: " + strconv.Itoa(len(m.OtherArchives)))
+	otherArchives := *m.OtherArchives
+	if len(otherArchives) != 2 {
+		t.Error("MailingLists.OtherArchives: expected len==2, got: " + strconv.Itoa(len(otherArchives)))
 	}
-	if m.OtherArchives[0] != "archive1" {
-		t.Error("MailingLists[0].OtherArchives[0]: expected 'archive1', got: " + m.OtherArchives[0])
+	if otherArchives[0] != "archive1" {
+		t.Error("MailingLists[0].OtherArchives[0]: expected 'archive1', got: " + otherArchives[0])
 	}
-	if m.OtherArchives[1] != "archive2" {
-		t.Error("MailingLists[0].OtherArchives[1]: expected 'archive2', got: " + m.OtherArchives[1])
+	if otherArchives[1] != "archive2" {
+		t.Error("MailingLists[0].OtherArchives[1]: expected 'archive2', got: " + otherArchives[1])
 	}
 }
 
 func TestParsing_Prerequisites(t *testing.T) {
-	if p.Prerequisites.Maven != "2.0" {
-		t.Error("Prerequisites.Maven: expected '2.0', got: " + p.Prerequisites.Maven)
+	if *p.Prerequisites.Maven != "2.0" {
+		t.Error("Prerequisites.Maven: expected '2.0', got: " + *p.Prerequisites.Maven)
 	}
 }
 
 func TestParsing_SCM(t *testing.T) {
-	if p.SCM.URL != "url" {
-		t.Error("SCM.URL: expected 'url', got: " + p.SCM.URL)
+	if *p.SCM.URL != "url" {
+		t.Error("SCM.URL: expected 'url', got: " + *p.SCM.URL)
 	}
-	if p.SCM.Connection != "connection" {
-		t.Error("SCM.Connection: expected 'connection', got: " + p.SCM.Connection)
+	if *p.SCM.Connection != "connection" {
+		t.Error("SCM.Connection: expected 'connection', got: " + *p.SCM.Connection)
 	}
-	if p.SCM.DeveloperConnection != "developerConnection" {
-		t.Error("SCM.DeveloperConnection: expected 'developerConnection', got: " + p.SCM.DeveloperConnection)
+	if *p.SCM.DeveloperConnection != "developerConnection" {
+		t.Error("SCM.DeveloperConnection: expected 'developerConnection', got: " + *p.SCM.DeveloperConnection)
 	}
-	if p.SCM.Tag != "tag" {
-		t.Error("SCM.Tag: expected 'tag', got: " + p.SCM.Tag)
+	if *p.SCM.Tag != "tag" {
+		t.Error("SCM.Tag: expected 'tag', got: " + *p.SCM.Tag)
 	}
 }
 
 func TestParsing_IssueManagement(t *testing.T) {
-	if p.IssueManagement.URL != "url" {
-		t.Error("IssueManagement.URL: expected 'url', got: " + p.IssueManagement.URL)
+	if *p.IssueManagement.URL != "url" {
+		t.Error("IssueManagement.URL: expected 'url', got: " + *p.IssueManagement.URL)
 	}
-	if p.IssueManagement.System != "system" {
-		t.Error("IssueManagement.System: expected 'system', got: " + p.IssueManagement.System)
+	if *p.IssueManagement.System != "system" {
+		t.Error("IssueManagement.System: expected 'system', got: " + *p.IssueManagement.System)
 	}
 }
 
 func TestParsing_CIManagement(t *testing.T) {
-	if p.CIManagement.System != "system" {
-		t.Error("CIManagement.System: expected 'system', got: " + p.CIManagement.System)
+	if *p.CIManagement.System != "system" {
+		t.Error("CIManagement.System: expected 'system', got: " + *p.CIManagement.System)
 	}
-	if p.CIManagement.URL != "url" {
-		t.Error("CIManagement.URL: expected 'url', got: " + p.CIManagement.URL)
+	if *p.CIManagement.URL != "url" {
+		t.Error("CIManagement.URL: expected 'url', got: " + *p.CIManagement.URL)
 	}
 }
 
 func TestParsing_Notifiers(t *testing.T) {
-	if len(p.CIManagement.Notifiers) != 1 {
-		t.Error("CIManagement.Notifiers: expected len==1, got: " + strconv.Itoa(len(p.CIManagement.Notifiers)))
+	notifiers := *p.CIManagement.Notifiers
+	if len(notifiers) != 1 {
+		t.Error("CIManagement.Notifiers: expected len==1, got: " + strconv.Itoa(len(notifiers)))
 	}
-	n := p.CIManagement.Notifiers[0]
-	if n.Type != "type" {
-		t.Error("CIManagement.Notifiers.Type: expected 'type', got: " + n.Type)
+	n := notifiers[0]
+	if *n.Type != "type" {
+		t.Error("CIManagement.Notifiers.Type: expected 'type', got: " + *n.Type)
 	}
-	if n.Address != "address" {
-		t.Error("CIManagement.Notifiers.Address: expected 'type', got: " + n.Address)
+	if *n.Address != "address" {
+		t.Error("CIManagement.Notifiers.Address: expected 'type', got: " + *n.Address)
 	}
-	if n.SendOnError != true {
-		t.Error("CIManagement.Notifiers.SendOnError: expected 'true', got: " + strconv.FormatBool(n.SendOnError))
+	if *n.SendOnError != true {
+		t.Error("CIManagement.Notifiers.SendOnError: expected 'true', got: " + strconv.FormatBool(*n.SendOnError))
 	}
-	if n.SendOnFailure != true {
-		t.Error("CIManagement.Notifiers.SendOnFailure: expected 'true', got: " + strconv.FormatBool(n.SendOnFailure))
+	if *n.SendOnFailure != true {
+		t.Error("CIManagement.Notifiers.SendOnFailure: expected 'true', got: " + strconv.FormatBool(*n.SendOnFailure))
 	}
-	if n.SendOnSuccess != true {
-		t.Error("CIManagement.Notifiers.SendOnSuccess: expected 'true', got: " + strconv.FormatBool(n.SendOnSuccess))
+	if *n.SendOnSuccess != true {
+		t.Error("CIManagement.Notifiers.SendOnSuccess: expected 'true', got: " + strconv.FormatBool(*n.SendOnSuccess))
 	}
-	if n.SendOnWarning != true {
-		t.Error("CIManagement.Notifiers.SendOnWarning: expected 'true', got: " + strconv.FormatBool(n.SendOnWarning))
+	if *n.SendOnWarning != true {
+		t.Error("CIManagement.Notifiers.SendOnWarning: expected 'true', got: " + strconv.FormatBool(*n.SendOnWarning))
 	}
 }
 
 func TestParsing_DistributionManagement(t *testing.T) {
-	assert.Equal(t, "downloadUrl", p.DistributionManagement.DownloadURL)
-	assert.Equal(t, "status", p.DistributionManagement.Status)
-	assert.Equal(t, "name", p.DistributionManagement.Repository.Name)
-	assert.Equal(t, "url", p.DistributionManagement.Repository.URL)
-	assert.Equal(t, "layout", p.DistributionManagement.Repository.Layout)
-	assert.Equal(t, true, p.DistributionManagement.Repository.UniqueVersion)
-	assert.Equal(t, "id", p.DistributionManagement.Repository.ID)
+	assert.Equal(t, "downloadUrl", *p.DistributionManagement.DownloadURL)
+	assert.Equal(t, "status", *p.DistributionManagement.Status)
+	assert.Equal(t, "name", *p.DistributionManagement.Repository.Name)
+	assert.Equal(t, "url", *p.DistributionManagement.Repository.URL)
+	assert.Equal(t, "layout", *p.DistributionManagement.Repository.Layout)
+	assert.Equal(t, true, *p.DistributionManagement.Repository.UniqueVersion)
+	assert.Equal(t, "id", *p.DistributionManagement.Repository.ID)
 	r := p.DistributionManagement.Repository.Releases
-	assert.Equal(t, "checksumPolicy", r.ChecksumPolicy)
-	assert.Equal(t, "enabled", r.Enabled)
-	assert.Equal(t, "updatePolicy", r.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *r.ChecksumPolicy)
+	assert.Equal(t, "enabled", *r.Enabled)
+	assert.Equal(t, "updatePolicy", *r.UpdatePolicy)
 	s := p.DistributionManagement.Repository.Snapshots
-	assert.Equal(t, "checksumPolicy", s.ChecksumPolicy)
-	assert.Equal(t, "enabled", s.Enabled)
-	assert.Equal(t, "updatePolicy", s.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *s.ChecksumPolicy)
+	assert.Equal(t, "enabled", *s.Enabled)
+	assert.Equal(t, "updatePolicy", *s.UpdatePolicy)
 
 	sr := p.DistributionManagement.SnapshotRepository
-	assert.Equal(t, "name", sr.Name)
-	assert.Equal(t, "url", sr.URL)
-	assert.Equal(t, "layout", sr.Layout)
-	assert.Equal(t, true, sr.UniqueVersion)
-	assert.Equal(t, "id", sr.ID)
+	assert.Equal(t, "name", *sr.Name)
+	assert.Equal(t, "url", *sr.URL)
+	assert.Equal(t, "layout", *sr.Layout)
+	assert.Equal(t, true, *sr.UniqueVersion)
+	assert.Equal(t, "id", *sr.ID)
 	r = sr.Releases
-	assert.Equal(t, "checksumPolicy", r.ChecksumPolicy)
-	assert.Equal(t, "enabled", r.Enabled)
-	assert.Equal(t, "updatePolicy", r.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *r.ChecksumPolicy)
+	assert.Equal(t, "enabled", *r.Enabled)
+	assert.Equal(t, "updatePolicy", *r.UpdatePolicy)
 	s = sr.Snapshots
-	assert.Equal(t, "checksumPolicy", s.ChecksumPolicy)
-	assert.Equal(t, "enabled", s.Enabled)
-	assert.Equal(t, "updatePolicy", s.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *s.ChecksumPolicy)
+	assert.Equal(t, "enabled", *s.Enabled)
+	assert.Equal(t, "updatePolicy", *s.UpdatePolicy)
 
 	rel := p.DistributionManagement.Relocation
-	assert.Equal(t, "version", rel.Version)
-	assert.Equal(t, "artifactId", rel.ArtifactID)
-	assert.Equal(t, "groupId", rel.GroupID)
-	assert.Equal(t, "message", rel.Message)
+	assert.Equal(t, "version", *rel.Version)
+	assert.Equal(t, "artifactId", *rel.ArtifactID)
+	assert.Equal(t, "groupId", *rel.GroupID)
+	assert.Equal(t, "message", *rel.Message)
 
 	site := p.DistributionManagement.Site
-	assert.Equal(t, "id", site.ID)
-	assert.Equal(t, "url", site.URL)
-	assert.Equal(t, "name", site.Name)
+	assert.Equal(t, "id", *site.ID)
+	assert.Equal(t, "url", *site.URL)
+	assert.Equal(t, "name", *site.Name)
 }
 
 func TestParsing_DependencyManagement(t *testing.T) {
-	assert.Equal(t, 1, len(p.DependencyManagement.Dependencies))
-	d := p.DependencyManagement.Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
+	assert.Equal(t, 1, len(*p.DependencyManagement.Dependencies))
+	d := (*p.DependencyManagement.Dependencies)[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+	assert.Equal(t, 1, len(*d.Exclusions))
+	assert.Equal(t, "artifactId", *(*d.Exclusions)[0].ArtifactID)
+	assert.Equal(t, "groupId", *(*d.Exclusions)[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
 }
 
 func TestParsing_Dependencies(t *testing.T) {
-	assert.Equal(t, 1, len(p.Dependencies))
-	d := p.Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
+	assert.Equal(t, 1, len(*p.Dependencies))
+	d := (*p.Dependencies)[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+	assert.Equal(t, 1, len(*d.Exclusions))
+	assert.Equal(t, "artifactId", *(*d.Exclusions)[0].ArtifactID)
+	assert.Equal(t, "groupId", *(*d.Exclusions)[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
 }
 
 func TestParsing_Repositories(t *testing.T) {
-	assert.Equal(t, 1, len(p.Repositories))
-	r := p.Repositories[0]
-	assert.Equal(t, "id", r.ID)
-	assert.Equal(t, "name", r.Name)
-	assert.Equal(t, "url", r.URL)
-	assert.Equal(t, "layout", r.Layout)
-	assert.Equal(t, "enabled", r.Releases.Enabled)
-	assert.Equal(t, "checksumPolicy", r.Releases.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", r.Releases.UpdatePolicy)
-	assert.Equal(t, "enabled", r.Snapshots.Enabled)
-	assert.Equal(t, "checksumPolicy", r.Snapshots.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", r.Snapshots.UpdatePolicy)
+	assert.Equal(t, 1, len(*p.Repositories))
+	r := (*p.Repositories)[0]
+	assert.Equal(t, "id", *r.ID)
+	assert.Equal(t, "name", *r.Name)
+	assert.Equal(t, "url", *r.URL)
+	assert.Equal(t, "layout", *r.Layout)
+	assert.Equal(t, "enabled", *r.Releases.Enabled)
+	assert.Equal(t, "checksumPolicy", *r.Releases.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *r.Releases.UpdatePolicy)
+	assert.Equal(t, "enabled", *r.Snapshots.Enabled)
+	assert.Equal(t, "checksumPolicy", *r.Snapshots.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *r.Snapshots.UpdatePolicy)
 }
 
 func TestParsing_PluginRepositories(t *testing.T) {
-	assert.Equal(t, 1, len(p.PluginRepositories))
-	pr := p.PluginRepositories[0]
-	assert.Equal(t, "id", pr.ID)
-	assert.Equal(t, "name", pr.Name)
-	assert.Equal(t, "url", pr.URL)
-	assert.Equal(t, "layout", pr.Layout)
-	assert.Equal(t, "enabled", pr.Releases.Enabled)
-	assert.Equal(t, "checksumPolicy", pr.Releases.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", pr.Releases.UpdatePolicy)
-	assert.Equal(t, "enabled", pr.Snapshots.Enabled)
-	assert.Equal(t, "checksumPolicy", pr.Snapshots.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", pr.Snapshots.UpdatePolicy)
+	assert.Equal(t, 1, len(*p.PluginRepositories))
+	pr := (*p.PluginRepositories)[0]
+	assert.Equal(t, "id", *pr.ID)
+	assert.Equal(t, "name", *pr.Name)
+	assert.Equal(t, "url", *pr.URL)
+	assert.Equal(t, "layout", *pr.Layout)
+	assert.Equal(t, "enabled", *pr.Releases.Enabled)
+	assert.Equal(t, "checksumPolicy", *pr.Releases.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *pr.Releases.UpdatePolicy)
+	assert.Equal(t, "enabled", *pr.Snapshots.Enabled)
+	assert.Equal(t, "checksumPolicy", *pr.Snapshots.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *pr.Snapshots.UpdatePolicy)
 }
 
 func TestParsing_Build(t *testing.T) {
 	b := p.Build
-	assert.Equal(t, "sourceDirectory", b.SourceDirectory)
-	assert.Equal(t, "scriptSourceDirectory", b.ScriptSourceDirectory)
-	assert.Equal(t, "testSourceDirectory", b.TestSourceDirectory)
-	assert.Equal(t, "outputDirectory", b.OutputDirectory)
-	assert.Equal(t, "testOutputDirectory", b.TestOutputDirectory)
-	assert.Equal(t, "directory", b.Directory)
-	assert.Equal(t, "defaultGoal", b.DefaultGoal)
-	assert.Equal(t, "finalName", b.FinalName)
-	assert.Equal(t, 1, len(b.Filters))
-	assert.Equal(t, "filter1", b.Filters[0])
+	assert.Equal(t, "sourceDirectory", *b.SourceDirectory)
+	assert.Equal(t, "scriptSourceDirectory", *b.ScriptSourceDirectory)
+	assert.Equal(t, "testSourceDirectory", *b.TestSourceDirectory)
+	assert.Equal(t, "outputDirectory", *b.OutputDirectory)
+	assert.Equal(t, "testOutputDirectory", *b.TestOutputDirectory)
+	assert.Equal(t, "directory", *b.Directory)
+	assert.Equal(t, "defaultGoal", *b.DefaultGoal)
+	assert.Equal(t, "finalName", *b.FinalName)
 
-	assert.Equal(t, 1, len(b.Extensions))
-	assert.Equal(t, "groupId", b.Extensions[0].GroupID)
-	assert.Equal(t, "artifactId", b.Extensions[0].ArtifactID)
-	assert.Equal(t, "version", b.Extensions[0].Version)
+	filters := *b.Filters
+	assert.Equal(t, 1, len(filters))
+	assert.Equal(t, "filter1", filters[0])
 
-	assert.Equal(t, 1, len(b.Resources))
-	assert.Equal(t, "targetPath", b.Resources[0].TargetPath)
-	assert.Equal(t, "filtering", b.Resources[0].Filtering)
-	assert.Equal(t, "directory", b.Resources[0].Directory)
-	assert.Equal(t, 1, len(b.Resources[0].Includes))
-	assert.Equal(t, "include", b.Resources[0].Includes[0])
-	assert.Equal(t, 1, len(b.Resources[0].Excludes))
-	assert.Equal(t, "exclude", b.Resources[0].Excludes[0])
+	extensions := *b.Extensions
+	assert.Equal(t, 1, len(extensions))
 
-	assert.Equal(t, 1, len(b.TestResources))
-	assert.Equal(t, "targetPath", b.TestResources[0].TargetPath)
-	assert.Equal(t, "filtering", b.TestResources[0].Filtering)
-	assert.Equal(t, "directory", b.TestResources[0].Directory)
-	assert.Equal(t, 1, len(b.TestResources[0].Includes))
-	assert.Equal(t, "include", b.TestResources[0].Includes[0])
-	assert.Equal(t, 1, len(b.TestResources[0].Excludes))
-	assert.Equal(t, "exclude", b.TestResources[0].Excludes[0])
+	firstExtension := extensions[0]
+	assert.Equal(t, "groupId", *firstExtension.GroupID)
+	assert.Equal(t, "artifactId", *firstExtension.ArtifactID)
+	assert.Equal(t, "version", *firstExtension.Version)
 
-	pl := b.PluginManagement.Plugins
+	resources := *b.Resources
+	assert.Equal(t, 1, len(resources))
+
+	firstResource := resources[0]
+	assert.Equal(t, "targetPath", *firstResource.TargetPath)
+	assert.Equal(t, "filtering", *firstResource.Filtering)
+	assert.Equal(t, "directory", *firstResource.Directory)
+	assert.Equal(t, 1, len(*firstResource.Includes))
+	assert.Equal(t, "include", (*firstResource.Includes)[0])
+	assert.Equal(t, 1, len(*firstResource.Excludes))
+	assert.Equal(t, "exclude", (*firstResource.Excludes)[0])
+
+	assert.Equal(t, 1, len(*b.TestResources))
+	assert.Equal(t, "targetPath", *(*b.TestResources)[0].TargetPath)
+	assert.Equal(t, "filtering", *(*b.TestResources)[0].Filtering)
+	assert.Equal(t, "directory", *(*b.TestResources)[0].Directory)
+	assert.Equal(t, 1, len(*(*b.TestResources)[0].Includes))
+	assert.Equal(t, "include", (*(*b.TestResources)[0].Includes)[0])
+	assert.Equal(t, 1, len(*(*b.TestResources)[0].Excludes))
+	assert.Equal(t, "exclude", (*(*b.TestResources)[0].Excludes)[0])
+
+	pl := *b.PluginManagement.Plugins
 	assert.Equal(t, 1, len(pl))
-	assert.Equal(t, "groupId", pl[0].GroupID)
-	assert.Equal(t, "artifactId", pl[0].ArtifactID)
-	assert.Equal(t, "version", pl[0].Version)
-	assert.Equal(t, "extensions", pl[0].Extensions)
-	assert.Equal(t, 1, len(pl[0].Executions))
-	assert.Equal(t, "id", pl[0].Executions[0].ID)
-	assert.Equal(t, "phase", pl[0].Executions[0].Phase)
-	assert.Equal(t, 1, len(pl[0].Executions[0].Goals))
-	assert.Equal(t, "goal", pl[0].Executions[0].Goals[0])
-	assert.Equal(t, "inherited", pl[0].Executions[0].Inherited)
-	assert.Equal(t, 3, len(pl[0].Executions[0].Configuration.Entries))
-	assert.Equal(t, "value", pl[0].Executions[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", pl[0].Executions[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", pl[0].Executions[0].Configuration.Entries["key3"])
+	assert.Equal(t, "groupId", *pl[0].GroupID)
+	assert.Equal(t, "artifactId", *pl[0].ArtifactID)
+	assert.Equal(t, "version", *pl[0].Version)
+	assert.Equal(t, "extensions", *pl[0].Extensions)
+	assert.Equal(t, 1, len(*pl[0].Executions))
+	assert.Equal(t, "id", *(*pl[0].Executions)[0].ID)
+	assert.Equal(t, "phase", *(*pl[0].Executions)[0].Phase)
+	assert.Equal(t, 1, len(*(*pl[0].Executions)[0].Goals))
+	assert.Equal(t, "goal", (*(*pl[0].Executions)[0].Goals)[0])
+	assert.Equal(t, "inherited", *(*pl[0].Executions)[0].Inherited)
+	assert.Equal(t, 3, len((*pl[0].Executions)[0].Configuration.Entries))
+	assert.Equal(t, "value", (*pl[0].Executions)[0].Configuration.Entries["key"])
+	assert.Equal(t, "value2", (*pl[0].Executions)[0].Configuration.Entries["key2"])
+	assert.Equal(t, "value3", (*pl[0].Executions)[0].Configuration.Entries["key3"])
 	assert.Equal(t, 3, len(pl[0].Configuration.Entries))
 	assert.Equal(t, "value", pl[0].Configuration.Entries["key"])
 	assert.Equal(t, "value2", pl[0].Configuration.Entries["key2"])
 	assert.Equal(t, "value3", pl[0].Configuration.Entries["key3"])
 
-	assert.Equal(t, 1, len(pl[0].Dependencies))
-	d := pl[0].Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
+	assert.Equal(t, 1, len(*pl[0].Dependencies))
+	d := (*pl[0].Dependencies)[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+	assert.Equal(t, 1, len(*d.Exclusions))
+	assert.Equal(t, "artifactId", *(*d.Exclusions)[0].ArtifactID)
+	assert.Equal(t, "groupId", *(*d.Exclusions)[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
 
-	pl = b.Plugins
+	pl = *b.Plugins
 	assert.Equal(t, 1, len(pl))
-	assert.Equal(t, "groupId", pl[0].GroupID)
-	assert.Equal(t, "artifactId", pl[0].ArtifactID)
-	assert.Equal(t, "version", pl[0].Version)
-	assert.Equal(t, "extensions", pl[0].Extensions)
-	assert.Equal(t, 1, len(pl[0].Executions))
-	assert.Equal(t, "id", pl[0].Executions[0].ID)
-	assert.Equal(t, "phase", pl[0].Executions[0].Phase)
-	assert.Equal(t, 1, len(pl[0].Executions[0].Goals))
-	assert.Equal(t, "goal", pl[0].Executions[0].Goals[0])
-	assert.Equal(t, "inherited", pl[0].Executions[0].Inherited)
-	assert.Equal(t, 3, len(pl[0].Executions[0].Configuration.Entries))
-	assert.Equal(t, "value", pl[0].Executions[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", pl[0].Executions[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", pl[0].Executions[0].Configuration.Entries["key3"])
+	assert.Equal(t, "groupId", *pl[0].GroupID)
+	assert.Equal(t, "artifactId", *pl[0].ArtifactID)
+	assert.Equal(t, "version", *pl[0].Version)
+	assert.Equal(t, "extensions", *pl[0].Extensions)
+	assert.Equal(t, 1, len(*pl[0].Executions))
+	assert.Equal(t, "id", *(*pl[0].Executions)[0].ID)
+	assert.Equal(t, "phase", *(*pl[0].Executions)[0].Phase)
+	assert.Equal(t, 1, len(*(*pl[0].Executions)[0].Goals))
+	assert.Equal(t, "goal", (*(*pl[0].Executions)[0].Goals)[0])
+	assert.Equal(t, "inherited", *(*pl[0].Executions)[0].Inherited)
+	assert.Equal(t, 3, len((*pl[0].Executions)[0].Configuration.Entries))
+	assert.Equal(t, "value", (*pl[0].Executions)[0].Configuration.Entries["key"])
+	assert.Equal(t, "value2", (*pl[0].Executions)[0].Configuration.Entries["key2"])
+	assert.Equal(t, "value3", (*pl[0].Executions)[0].Configuration.Entries["key3"])
 	assert.Equal(t, 3, len(pl[0].Configuration.Entries))
 	assert.Equal(t, "value", pl[0].Configuration.Entries["key"])
 	assert.Equal(t, "value2", pl[0].Configuration.Entries["key2"])
 	assert.Equal(t, "value3", pl[0].Configuration.Entries["key3"])
 
-	assert.Equal(t, 1, len(pl[0].Dependencies))
-	d = pl[0].Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
+	assert.Equal(t, 1, len(*pl[0].Dependencies))
+	d = (*pl[0].Dependencies)[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+	assert.Equal(t, 1, len(*d.Exclusions))
+	assert.Equal(t, "artifactId", *(*d.Exclusions)[0].ArtifactID)
+	assert.Equal(t, "groupId", *(*d.Exclusions)[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
 }
 
 func TestParsing_Reporting(t *testing.T) {
-	assert.Equal(t, "excludeDefaults", p.Reporting.ExcludeDefaults)
-	assert.Equal(t, "outputDirectory", p.Reporting.OutputDirectory)
-	assert.Equal(t, "outputDirectory", p.Reporting.OutputDirectory)
+	assert.Equal(t, "excludeDefaults", *p.Reporting.ExcludeDefaults)
+	assert.Equal(t, "outputDirectory", *p.Reporting.OutputDirectory)
+	assert.Equal(t, "outputDirectory", *p.Reporting.OutputDirectory)
 
-	pl := p.Reporting.Plugins
+	pl := *p.Reporting.Plugins
+	firstPlugin := pl[0]
 	assert.Equal(t, 1, len(pl))
-	assert.Equal(t, "groupId", pl[0].GroupID)
-	assert.Equal(t, "artifactId", pl[0].ArtifactID)
-	assert.Equal(t, "version", pl[0].Version)
-	assert.Equal(t, 1, len(pl[0].ReportSets))
-	assert.Equal(t, "id", pl[0].ReportSets[0].ID)
-	assert.Equal(t, 1, len(pl[0].ReportSets[0].Reports))
-	assert.Equal(t, "report", pl[0].ReportSets[0].Reports[0])
-	assert.Equal(t, "inherited", pl[0].ReportSets[0].Inherited)
-	assert.Equal(t, 3, len(pl[0].ReportSets[0].Configuration.Entries))
-	assert.Equal(t, "value", pl[0].ReportSets[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", pl[0].ReportSets[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", pl[0].ReportSets[0].Configuration.Entries["key3"])
-	assert.Equal(t, 3, len(pl[0].Configuration.Entries))
-	assert.Equal(t, "value", pl[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", pl[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", pl[0].Configuration.Entries["key3"])
+	assert.Equal(t, "groupId", *firstPlugin.GroupID)
+	assert.Equal(t, "artifactId", *firstPlugin.ArtifactID)
+	assert.Equal(t, "version", *firstPlugin.Version)
+	assert.Equal(t, 3, len(firstPlugin.Configuration.Entries))
+	assert.Equal(t, "value", firstPlugin.Configuration.Entries["key"])
+	assert.Equal(t, "value2", firstPlugin.Configuration.Entries["key2"])
+	assert.Equal(t, "value3", firstPlugin.Configuration.Entries["key3"])
+
+	reportSets := *firstPlugin.ReportSets
+	assert.Equal(t, 1, len(reportSets))
+
+	firstReportSet := reportSets[0]
+	assert.Equal(t, "id", *firstReportSet.ID)
+	assert.Equal(t, "inherited", *firstReportSet.Inherited)
+	assert.Equal(t, 3, len(firstReportSet.Configuration.Entries))
+	assert.Equal(t, "value", firstReportSet.Configuration.Entries["key"])
+	assert.Equal(t, "value2", firstReportSet.Configuration.Entries["key2"])
+	assert.Equal(t, "value3", firstReportSet.Configuration.Entries["key3"])
+
+	reports := *firstReportSet.Reports
+	assert.Equal(t, 1, len(reports))
+	assert.Equal(t, "report", reports[0])
 }
 
 func TestParsing_Profiles(t *testing.T) {
-	assert.Equal(t, 1, len(p.Profiles))
-	assert.Equal(t, "id", p.Profiles[0].ID)
-	assert.Equal(t, true, p.Profiles[0].Activation.ActiveByDefault)
-	assert.Equal(t, "jdk", p.Profiles[0].Activation.JDK)
-	assert.Equal(t, "name", p.Profiles[0].Activation.OS.Name)
-	assert.Equal(t, "family", p.Profiles[0].Activation.OS.Family)
-	assert.Equal(t, "arch", p.Profiles[0].Activation.OS.Arch)
-	assert.Equal(t, "version", p.Profiles[0].Activation.OS.Version)
-	assert.Equal(t, "name", p.Profiles[0].Activation.Property.Name)
-	assert.Equal(t, "value", p.Profiles[0].Activation.Property.Value)
-	assert.Equal(t, "missing", p.Profiles[0].Activation.File.Missing)
-	assert.Equal(t, "exists", p.Profiles[0].Activation.File.Exists)
+	profiles := *p.Profiles
+	assert.Equal(t, 1, len(profiles))
 
-	b := p.Profiles[0].Build
-	assert.Equal(t, "directory", b.Directory)
-	assert.Equal(t, "defaultGoal", b.DefaultGoal)
-	assert.Equal(t, "finalName", b.FinalName)
-	assert.Equal(t, 1, len(b.Filters))
-	assert.Equal(t, "filter1", b.Filters[0])
+	firstProfile := profiles[0]
+	assert.Equal(t, "id", *firstProfile.ID)
+	assert.Equal(t, true, *firstProfile.Activation.ActiveByDefault)
+	assert.Equal(t, "jdk", *firstProfile.Activation.JDK)
+	assert.Equal(t, "name", *firstProfile.Activation.OS.Name)
+	assert.Equal(t, "family", *firstProfile.Activation.OS.Family)
+	assert.Equal(t, "arch", *firstProfile.Activation.OS.Arch)
+	assert.Equal(t, "version", *firstProfile.Activation.OS.Version)
+	assert.Equal(t, "name", *firstProfile.Activation.Property.Name)
+	assert.Equal(t, "value", *firstProfile.Activation.Property.Value)
+	assert.Equal(t, "missing", *firstProfile.Activation.File.Missing)
+	assert.Equal(t, "exists", *firstProfile.Activation.File.Exists)
 
-	assert.Equal(t, 1, len(b.Resources))
-	assert.Equal(t, "targetPath", b.Resources[0].TargetPath)
-	assert.Equal(t, "filtering", b.Resources[0].Filtering)
-	assert.Equal(t, "directory", b.Resources[0].Directory)
-	assert.Equal(t, 1, len(b.Resources[0].Includes))
-	assert.Equal(t, "include", b.Resources[0].Includes[0])
-	assert.Equal(t, 1, len(b.Resources[0].Excludes))
-	assert.Equal(t, "exclude", b.Resources[0].Excludes[0])
+	b := firstProfile.Build
+	assert.Equal(t, "directory", *b.Directory)
+	assert.Equal(t, "defaultGoal", *b.DefaultGoal)
+	assert.Equal(t, "finalName", *b.FinalName)
 
-	assert.Equal(t, 1, len(b.TestResources))
-	assert.Equal(t, "targetPath", b.TestResources[0].TargetPath)
-	assert.Equal(t, "filtering", b.TestResources[0].Filtering)
-	assert.Equal(t, "directory", b.TestResources[0].Directory)
-	assert.Equal(t, 1, len(b.TestResources[0].Includes))
-	assert.Equal(t, "include", b.TestResources[0].Includes[0])
-	assert.Equal(t, 1, len(b.TestResources[0].Excludes))
-	assert.Equal(t, "exclude", b.TestResources[0].Excludes[0])
+	filters := *b.Filters
+	assert.Equal(t, 1, len(filters))
 
-	pl := b.PluginManagement.Plugins
+	firstFilter := filters[0]
+	assert.Equal(t, "filter1", firstFilter)
+
+	resources := *b.Resources
+	assert.Equal(t, 1, len(resources))
+
+	firstResource := resources[0]
+	assert.Equal(t, "targetPath", *firstResource.TargetPath)
+	assert.Equal(t, "filtering", *firstResource.Filtering)
+	assert.Equal(t, "directory", *firstResource.Directory)
+
+	includes := *firstResource.Includes
+	assert.Equal(t, 1, len(includes))
+	assert.Equal(t, "include", includes[0])
+
+	excludes := *firstResource.Excludes
+	assert.Equal(t, 1, len(excludes))
+	assert.Equal(t, "exclude", excludes[0])
+
+	testResources := *b.TestResources
+	assert.Equal(t, 1, len(testResources))
+
+	firstTestResource := testResources[0]
+	assert.Equal(t, "targetPath", *firstTestResource.TargetPath)
+	assert.Equal(t, "filtering", *firstTestResource.Filtering)
+	assert.Equal(t, "directory", *firstTestResource.Directory)
+
+	testResourceIncludes := *firstTestResource.Includes
+	assert.Equal(t, 1, len(testResourceIncludes))
+	assert.Equal(t, "include", testResourceIncludes[0])
+
+	testResourceExcludes := *firstTestResource.Excludes
+	assert.Equal(t, 1, len(testResourceExcludes))
+	assert.Equal(t, "exclude", testResourceExcludes[0])
+
+	pl := *b.PluginManagement.Plugins
 	assert.Equal(t, 1, len(pl))
-	assert.Equal(t, "groupId", pl[0].GroupID)
-	assert.Equal(t, "artifactId", pl[0].ArtifactID)
-	assert.Equal(t, "version", pl[0].Version)
-	assert.Equal(t, "extensions", pl[0].Extensions)
-	assert.Equal(t, 1, len(pl[0].Executions))
-	assert.Equal(t, "id", pl[0].Executions[0].ID)
-	assert.Equal(t, "phase", pl[0].Executions[0].Phase)
-	assert.Equal(t, 1, len(pl[0].Executions[0].Goals))
-	assert.Equal(t, "goal", pl[0].Executions[0].Goals[0])
-	assert.Equal(t, "inherited", pl[0].Executions[0].Inherited)
-	assert.Equal(t, 3, len(pl[0].Executions[0].Configuration.Entries))
-	assert.Equal(t, "value", pl[0].Executions[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", pl[0].Executions[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", pl[0].Executions[0].Configuration.Entries["key3"])
+
+	firstPlugin := pl[0]
+	assert.Equal(t, "groupId", *firstPlugin.GroupID)
+	assert.Equal(t, "artifactId", *firstPlugin.ArtifactID)
+	assert.Equal(t, "version", *firstPlugin.Version)
+	assert.Equal(t, "extensions", *firstPlugin.Extensions)
+	assert.Equal(t, 3, len(firstPlugin.Configuration.Entries))
+	assert.Equal(t, "value", firstPlugin.Configuration.Entries["key"])
+	assert.Equal(t, "value2", firstPlugin.Configuration.Entries["key2"])
+	assert.Equal(t, "value3", firstPlugin.Configuration.Entries["key3"])
+
+	pluginExecutions := *firstPlugin.Executions
+	assert.Equal(t, 1, len(pluginExecutions))
+
+	firstPluginExecution := pluginExecutions[0]
+	assert.Equal(t, "id", *firstPluginExecution.ID)
+	assert.Equal(t, "phase", *firstPluginExecution.Phase)
+	assert.Equal(t, "inherited", *firstPluginExecution.Inherited)
+	assert.Equal(t, 3, len(firstPluginExecution.Configuration.Entries))
+	assert.Equal(t, "value", firstPluginExecution.Configuration.Entries["key"])
+	assert.Equal(t, "value2", firstPluginExecution.Configuration.Entries["key2"])
+	assert.Equal(t, "value3", firstPluginExecution.Configuration.Entries["key3"])
+
+	firstPluginExecutionGoals := *firstPluginExecution.Goals
+	assert.Equal(t, 1, len(firstPluginExecutionGoals))
+	assert.Equal(t, "goal", firstPluginExecutionGoals[0])
+
+	firstPluginDependencies := *firstPlugin.Dependencies
+	assert.Equal(t, 1, len(firstPluginDependencies))
+	d := firstPluginDependencies[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+
+	dExclusions := *d.Exclusions
+	assert.Equal(t, 1, len(dExclusions))
+	assert.Equal(t, "artifactId", *dExclusions[0].ArtifactID)
+	assert.Equal(t, "groupId", *dExclusions[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
+
+	pl = *b.Plugins
+	assert.Equal(t, 1, len(pl))
+	assert.Equal(t, "groupId", *pl[0].GroupID)
+	assert.Equal(t, "artifactId", *pl[0].ArtifactID)
+	assert.Equal(t, "version", *pl[0].Version)
+	assert.Equal(t, "extensions", *pl[0].Extensions)
+
+	plExecutions := *pl[0].Executions
+	assert.Equal(t, 1, len(plExecutions))
+	assert.Equal(t, "id", *plExecutions[0].ID)
+	assert.Equal(t, "phase", *plExecutions[0].Phase)
+	assert.Equal(t, 1, len(*(*pl[0].Executions)[0].Goals))
+	assert.Equal(t, "goal", (*(*pl[0].Executions)[0].Goals)[0])
+	assert.Equal(t, "inherited", *(*pl[0].Executions)[0].Inherited)
+	assert.Equal(t, 3, len((*pl[0].Executions)[0].Configuration.Entries))
+	assert.Equal(t, "value", (*pl[0].Executions)[0].Configuration.Entries["key"])
+	assert.Equal(t, "value2", (*pl[0].Executions)[0].Configuration.Entries["key2"])
+	assert.Equal(t, "value3", (*pl[0].Executions)[0].Configuration.Entries["key3"])
 	assert.Equal(t, 3, len(pl[0].Configuration.Entries))
 	assert.Equal(t, "value", pl[0].Configuration.Entries["key"])
 	assert.Equal(t, "value2", pl[0].Configuration.Entries["key2"])
 	assert.Equal(t, "value3", pl[0].Configuration.Entries["key3"])
 
-	assert.Equal(t, 1, len(pl[0].Dependencies))
-	d := pl[0].Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
+	assert.Equal(t, 1, len(*pl[0].Dependencies))
+	d = (*pl[0].Dependencies)[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+	assert.Equal(t, 1, len(*d.Exclusions))
+	assert.Equal(t, "artifactId", *(*d.Exclusions)[0].ArtifactID)
+	assert.Equal(t, "groupId", *(*d.Exclusions)[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
 
-	pl = b.Plugins
-	assert.Equal(t, 1, len(pl))
-	assert.Equal(t, "groupId", pl[0].GroupID)
-	assert.Equal(t, "artifactId", pl[0].ArtifactID)
-	assert.Equal(t, "version", pl[0].Version)
-	assert.Equal(t, "extensions", pl[0].Extensions)
-	assert.Equal(t, 1, len(pl[0].Executions))
-	assert.Equal(t, "id", pl[0].Executions[0].ID)
-	assert.Equal(t, "phase", pl[0].Executions[0].Phase)
-	assert.Equal(t, 1, len(pl[0].Executions[0].Goals))
-	assert.Equal(t, "goal", pl[0].Executions[0].Goals[0])
-	assert.Equal(t, "inherited", pl[0].Executions[0].Inherited)
-	assert.Equal(t, 3, len(pl[0].Executions[0].Configuration.Entries))
-	assert.Equal(t, "value", pl[0].Executions[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", pl[0].Executions[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", pl[0].Executions[0].Configuration.Entries["key3"])
-	assert.Equal(t, 3, len(pl[0].Configuration.Entries))
-	assert.Equal(t, "value", pl[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", pl[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", pl[0].Configuration.Entries["key3"])
+	assert.Equal(t, "module1", (*(*p.Profiles)[0].Modules)[0])
 
-	assert.Equal(t, 1, len(pl[0].Dependencies))
-	d = pl[0].Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
-
-	assert.Equal(t, "module1", p.Profiles[0].Modules[0])
-
-	dm := p.Profiles[0].DistributionManagement
-	assert.Equal(t, "downloadUrl", dm.DownloadURL)
-	assert.Equal(t, "status", dm.Status)
-	assert.Equal(t, "name", dm.Repository.Name)
-	assert.Equal(t, "url", dm.Repository.URL)
-	assert.Equal(t, "layout", dm.Repository.Layout)
-	assert.Equal(t, true, dm.Repository.UniqueVersion)
-	assert.Equal(t, "id", dm.Repository.ID)
+	dm := (*p.Profiles)[0].DistributionManagement
+	assert.Equal(t, "downloadUrl", *dm.DownloadURL)
+	assert.Equal(t, "status", *dm.Status)
+	assert.Equal(t, "name", *dm.Repository.Name)
+	assert.Equal(t, "url", *dm.Repository.URL)
+	assert.Equal(t, "layout", *dm.Repository.Layout)
+	assert.Equal(t, true, *dm.Repository.UniqueVersion)
+	assert.Equal(t, "id", *dm.Repository.ID)
 	r := dm.Repository.Releases
-	assert.Equal(t, "checksumPolicy", r.ChecksumPolicy)
-	assert.Equal(t, "enabled", r.Enabled)
-	assert.Equal(t, "updatePolicy", r.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *r.ChecksumPolicy)
+	assert.Equal(t, "enabled", *r.Enabled)
+	assert.Equal(t, "updatePolicy", *r.UpdatePolicy)
 	s := dm.Repository.Snapshots
-	assert.Equal(t, "checksumPolicy", s.ChecksumPolicy)
-	assert.Equal(t, "enabled", s.Enabled)
-	assert.Equal(t, "updatePolicy", s.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *s.ChecksumPolicy)
+	assert.Equal(t, "enabled", *s.Enabled)
+	assert.Equal(t, "updatePolicy", *s.UpdatePolicy)
 
 	sr := dm.SnapshotRepository
-	assert.Equal(t, "name", sr.Name)
-	assert.Equal(t, "url", sr.URL)
-	assert.Equal(t, "layout", sr.Layout)
-	assert.Equal(t, true, sr.UniqueVersion)
-	assert.Equal(t, "id", sr.ID)
+	assert.Equal(t, "name", *sr.Name)
+	assert.Equal(t, "url", *sr.URL)
+	assert.Equal(t, "layout", *sr.Layout)
+	assert.Equal(t, true, *sr.UniqueVersion)
+	assert.Equal(t, "id", *sr.ID)
 	r = sr.Releases
-	assert.Equal(t, "checksumPolicy", r.ChecksumPolicy)
-	assert.Equal(t, "enabled", r.Enabled)
-	assert.Equal(t, "updatePolicy", r.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *r.ChecksumPolicy)
+	assert.Equal(t, "enabled", *r.Enabled)
+	assert.Equal(t, "updatePolicy", *r.UpdatePolicy)
 	s = sr.Snapshots
-	assert.Equal(t, "checksumPolicy", s.ChecksumPolicy)
-	assert.Equal(t, "enabled", s.Enabled)
-	assert.Equal(t, "updatePolicy", s.UpdatePolicy)
+	assert.Equal(t, "checksumPolicy", *s.ChecksumPolicy)
+	assert.Equal(t, "enabled", *s.Enabled)
+	assert.Equal(t, "updatePolicy", *s.UpdatePolicy)
 
 	rel := dm.Relocation
-	assert.Equal(t, "version", rel.Version)
-	assert.Equal(t, "artifactId", rel.ArtifactID)
-	assert.Equal(t, "groupId", rel.GroupID)
-	assert.Equal(t, "message", rel.Message)
+	assert.Equal(t, "version", *rel.Version)
+	assert.Equal(t, "artifactId", *rel.ArtifactID)
+	assert.Equal(t, "groupId", *rel.GroupID)
+	assert.Equal(t, "message", *rel.Message)
 
 	site := dm.Site
-	assert.Equal(t, "id", site.ID)
-	assert.Equal(t, "url", site.URL)
-	assert.Equal(t, "name", site.Name)
+	assert.Equal(t, "id", *site.ID)
+	assert.Equal(t, "url", *site.URL)
+	assert.Equal(t, "name", *site.Name)
 
-	dMan := p.Profiles[0].DependencyManagement
-	assert.Equal(t, 1, len(dMan.Dependencies))
-	d = dMan.Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
+	dMan := (*p.Profiles)[0].DependencyManagement
+	assert.Equal(t, 1, len(*dMan.Dependencies))
+	d = (*dMan.Dependencies)[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+	assert.Equal(t, 1, len(*d.Exclusions))
+	assert.Equal(t, "artifactId", *(*d.Exclusions)[0].ArtifactID)
+	assert.Equal(t, "groupId", *(*d.Exclusions)[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
 
-	d = p.Profiles[0].Dependencies[0]
-	assert.Equal(t, "groupId", d.GroupID)
-	assert.Equal(t, "artifactId", d.ArtifactID)
-	assert.Equal(t, "version", d.Version)
-	assert.Equal(t, "type", d.Type)
-	assert.Equal(t, "classifier", d.Classifier)
-	assert.Equal(t, 1, len(d.Exclusions))
-	assert.Equal(t, "artifactId", d.Exclusions[0].ArtifactID)
-	assert.Equal(t, "groupId", d.Exclusions[0].GroupID)
-	assert.Equal(t, "optional", d.Optional)
-	assert.Equal(t, "scope", d.Scope)
-	assert.Equal(t, "systemPath", d.SystemPath)
+	d = (*(*p.Profiles)[0].Dependencies)[0]
+	assert.Equal(t, "groupId", *d.GroupID)
+	assert.Equal(t, "artifactId", *d.ArtifactID)
+	assert.Equal(t, "version", *d.Version)
+	assert.Equal(t, "type", *d.Type)
+	assert.Equal(t, "classifier", *d.Classifier)
+	assert.Equal(t, 1, len(*d.Exclusions))
+	assert.Equal(t, "artifactId", *(*d.Exclusions)[0].ArtifactID)
+	assert.Equal(t, "groupId", *(*d.Exclusions)[0].GroupID)
+	assert.Equal(t, "optional", *d.Optional)
+	assert.Equal(t, "scope", *d.Scope)
+	assert.Equal(t, "systemPath", *d.SystemPath)
 
-	rep := p.Profiles[0].Repositories[0]
-	assert.Equal(t, "id", rep.ID)
-	assert.Equal(t, "name", rep.Name)
-	assert.Equal(t, "url", rep.URL)
-	assert.Equal(t, "layout", rep.Layout)
-	assert.Equal(t, "enabled", rep.Releases.Enabled)
-	assert.Equal(t, "checksumPolicy", rep.Releases.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", rep.Releases.UpdatePolicy)
-	assert.Equal(t, "enabled", rep.Snapshots.Enabled)
-	assert.Equal(t, "checksumPolicy", rep.Snapshots.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", rep.Snapshots.UpdatePolicy)
+	rep := (*(*p.Profiles)[0].Repositories)[0]
+	assert.Equal(t, "id", *rep.ID)
+	assert.Equal(t, "name", *rep.Name)
+	assert.Equal(t, "url", *rep.URL)
+	assert.Equal(t, "layout", *rep.Layout)
+	assert.Equal(t, "enabled", *rep.Releases.Enabled)
+	assert.Equal(t, "checksumPolicy", *rep.Releases.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *rep.Releases.UpdatePolicy)
+	assert.Equal(t, "enabled", *rep.Snapshots.Enabled)
+	assert.Equal(t, "checksumPolicy", *rep.Snapshots.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *rep.Snapshots.UpdatePolicy)
 
-	pluRep := p.Profiles[0].PluginRepositories[0]
-	assert.Equal(t, "id", pluRep.ID)
-	assert.Equal(t, "name", pluRep.Name)
-	assert.Equal(t, "url", pluRep.URL)
-	assert.Equal(t, "layout", pluRep.Layout)
-	assert.Equal(t, "enabled", pluRep.Releases.Enabled)
-	assert.Equal(t, "checksumPolicy", pluRep.Releases.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", pluRep.Releases.UpdatePolicy)
-	assert.Equal(t, "enabled", pluRep.Snapshots.Enabled)
-	assert.Equal(t, "checksumPolicy", pluRep.Snapshots.ChecksumPolicy)
-	assert.Equal(t, "updatePolicy", pluRep.Snapshots.UpdatePolicy)
+	pluRep := (*(*p.Profiles)[0].PluginRepositories)[0]
+	assert.Equal(t, "id", *pluRep.ID)
+	assert.Equal(t, "name", *pluRep.Name)
+	assert.Equal(t, "url", *pluRep.URL)
+	assert.Equal(t, "layout", *pluRep.Layout)
+	assert.Equal(t, "enabled", *pluRep.Releases.Enabled)
+	assert.Equal(t, "checksumPolicy", *pluRep.Releases.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *pluRep.Releases.UpdatePolicy)
+	assert.Equal(t, "enabled", *pluRep.Snapshots.Enabled)
+	assert.Equal(t, "checksumPolicy", *pluRep.Snapshots.ChecksumPolicy)
+	assert.Equal(t, "updatePolicy", *pluRep.Snapshots.UpdatePolicy)
 
-	reporting := p.Profiles[0].Reporting
-	assert.Equal(t, "excludeDefaults", reporting.ExcludeDefaults)
-	assert.Equal(t, "outputDirectory", reporting.OutputDirectory)
-	assert.Equal(t, "outputDirectory", reporting.OutputDirectory)
+	reporting := (*p.Profiles)[0].Reporting
+	assert.Equal(t, "excludeDefaults", *reporting.ExcludeDefaults)
+	assert.Equal(t, "outputDirectory", *reporting.OutputDirectory)
+	assert.Equal(t, "outputDirectory", *reporting.OutputDirectory)
 
 	repPl := reporting.Plugins
-	assert.Equal(t, 1, len(repPl))
-	assert.Equal(t, "groupId", repPl[0].GroupID)
-	assert.Equal(t, "artifactId", repPl[0].ArtifactID)
-	assert.Equal(t, "version", repPl[0].Version)
-	assert.Equal(t, "inherited", repPl[0].Inherited)
-	assert.Equal(t, 1, len(repPl[0].ReportSets))
-	assert.Equal(t, "id", repPl[0].ReportSets[0].ID)
-	assert.Equal(t, 1, len(repPl[0].ReportSets[0].Reports))
-	assert.Equal(t, "report", repPl[0].ReportSets[0].Reports[0])
-	assert.Equal(t, "inherited", repPl[0].ReportSets[0].Inherited)
-	assert.Equal(t, 3, len(repPl[0].ReportSets[0].Configuration.Entries))
-	assert.Equal(t, "value", repPl[0].ReportSets[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", repPl[0].ReportSets[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", repPl[0].ReportSets[0].Configuration.Entries["key3"])
-	assert.Equal(t, 3, len(repPl[0].Configuration.Entries))
-	assert.Equal(t, "value", repPl[0].Configuration.Entries["key"])
-	assert.Equal(t, "value2", repPl[0].Configuration.Entries["key2"])
-	assert.Equal(t, "value3", repPl[0].Configuration.Entries["key3"])
+	assert.Equal(t, 1, len(*repPl))
+	assert.Equal(t, "groupId", *(*repPl)[0].GroupID)
+	assert.Equal(t, "artifactId", *(*repPl)[0].ArtifactID)
+	assert.Equal(t, "version", *(*repPl)[0].Version)
+	assert.Equal(t, "inherited", *(*repPl)[0].Inherited)
+	assert.Equal(t, 1, len(*(*repPl)[0].ReportSets))
+	assert.Equal(t, "id", *(*(*repPl)[0].ReportSets)[0].ID)
+	assert.Equal(t, 1, len(*(*(*repPl)[0].ReportSets)[0].Reports))
+	assert.Equal(t, "report", (*(*(*repPl)[0].ReportSets)[0].Reports)[0])
+	assert.Equal(t, "inherited", *(*(*repPl)[0].ReportSets)[0].Inherited)
+	assert.Equal(t, 3, len((*(*repPl)[0].ReportSets)[0].Configuration.Entries))
+	assert.Equal(t, "value", (*(*repPl)[0].ReportSets)[0].Configuration.Entries["key"])
+	assert.Equal(t, "value2", (*(*repPl)[0].ReportSets)[0].Configuration.Entries["key2"])
+	assert.Equal(t, "value3", (*(*repPl)[0].ReportSets)[0].Configuration.Entries["key3"])
+	assert.Equal(t, 3, len((*repPl)[0].Configuration.Entries))
+	assert.Equal(t, "value", (*repPl)[0].Configuration.Entries["key"])
+	assert.Equal(t, "value2", (*repPl)[0].Configuration.Entries["key2"])
+	assert.Equal(t, "value3", (*repPl)[0].Configuration.Entries["key3"])
 }
 
 func Test_ParsingParentProperties(t *testing.T) {
@@ -751,43 +810,46 @@ func Test_ParsingParentProperties(t *testing.T) {
 }
 
 func Test_ParsingDeveloperProperties(t *testing.T) {
-	assert.Equal(t, 3, len(p.Developers[0].Properties.Entries))
+	assert.Equal(t, 3, len((*p.Developers)[0].Properties.Entries))
 	assert.Equal(t, "value", p.Properties.Entries["key"])
 	assert.Equal(t, "value2", p.Properties.Entries["key2"])
 	assert.Equal(t, "value3", p.Properties.Entries["key3"])
 }
 
 func Test_ParsingContributorProperties(t *testing.T) {
-	assert.Equal(t, 3, len(p.Contributors[0].Properties.Entries))
+	assert.Equal(t, 3, len((*p.Contributors)[0].Properties.Entries))
 	assert.Equal(t, "value", p.Properties.Entries["key"])
 	assert.Equal(t, "value2", p.Properties.Entries["key2"])
 	assert.Equal(t, "value3", p.Properties.Entries["key3"])
 }
 
 func Test_ParsingProfileProperties(t *testing.T) {
-	assert.Equal(t, 3, len(p.Profiles[0].Properties.Entries))
+	assert.Equal(t, 3, len((*p.Profiles)[0].Properties.Entries))
 	assert.Equal(t, "value", p.Properties.Entries["key"])
 	assert.Equal(t, "value2", p.Properties.Entries["key2"])
 	assert.Equal(t, "value3", p.Properties.Entries["key3"])
 }
 
 func Test_ParsingNotifierConfigurations(t *testing.T) {
-	assert.Equal(t, 3, len(p.CIManagement.Notifiers[0].Configuration.Entries))
+	assert.Equal(t, 3, len((*p.CIManagement.Notifiers)[0].Configuration.Entries))
 	assert.Equal(t, "value", p.Properties.Entries["key"])
 	assert.Equal(t, "value2", p.Properties.Entries["key2"])
 	assert.Equal(t, "value3", p.Properties.Entries["key3"])
 }
 
 func Test_MarshalingProjectToXML(t *testing.T) {
+	groupId := "org.apache.ignite"
+	artifactId := "ignite-core"
+	version := "2.14.0"
 	ignitePlugin := Plugin{
-		GroupID:       "org.apache.ignite",
-		ArtifactID:    "ignite-core",
-		Version:       "2.14.0",
-		Configuration: Properties{Entries: map[string]string{}},
+		GroupID:       &groupId,
+		ArtifactID:    &artifactId,
+		Version:       &version,
+		Configuration: &Properties{Entries: map[string]string{}},
 	}
 
 	// Add plugin to build plugins of original project p and marshal it to XML.
-	p.Build.Plugins = append(p.Build.Plugins, ignitePlugin)
+	*p.Build.Plugins = append(*p.Build.Plugins, ignitePlugin)
 
 	// Marshal the pom back to xml
 	marshaledXml, err := xml.MarshalIndent(p, "  ", "    ")
@@ -800,4 +862,17 @@ func Test_MarshalingProjectToXML(t *testing.T) {
 
 	// Check that the two object are equal.
 	assert.Equal(t, p, parsedPom)
+}
+
+func Test_MarshallingShouldOmitEmpty(t *testing.T) {
+	name := "testing"
+	pom := Project{
+		Name: &name,
+	}
+
+	marshaledXml, err := xml.MarshalIndent(pom, "", "")
+	assert.Nil(t, err)
+
+	// Should only include the properties added
+	assert.Equal(t, string(marshaledXml), "<project><name>testing</name></project>")
 }


### PR DESCRIPTION
Fix to issue #6.

To make this work the fields of the structs needed to be changed to pointers to be able to represent the nil case. If not we would get empty nestled structs, even though we might not have initialised them on our own. This means that this is a breaking change and will result in a new major version when merged.